### PR TITLE
Bump Cargo.lock and support other branches

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,11 @@ inputs:
     description: 'Github Action access token for creating a version bump PR automatically. This should be a personal access token, and _not_ the standard secret token (which cannot push/trigger other actions, such as release steps on tag eg). But also different to any token needed for automatic merging of PRs...'
     required: true
 
+  target_branch:
+    description: The branch to compare against
+    required: true
+    default: main
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const bump = async () => {
         
         if( token.length === 0 ) {
             core.setFailed("`token` must be set")
+            return
         }
 
         await exec.exec('git config --local user.email "action@github.com"');

--- a/index.js
+++ b/index.js
@@ -64,15 +64,31 @@ const bump = async () => {
         core.debug(`Commit message added was: ${commit_message}`);
 
         // parse and update cargo.toml
-        let cargo = fs.readFileSync('Cargo.toml');
+        const manifest = toml.parse(fs.readFileSync('Cargo.toml', 'utf8'));
+        manifest.package.version = cargo_version;
+        fs.writeFileSync('Cargo.toml', toml.stringify(manifest));
 
-        var json = toml.parse(cargo);
-        // special vargo version to remove "v"
-        json.package.version = cargo_version;
+        // parse and update Cargo.lock (if present)
+        let lockfile;
+        try {
+          lockfile = toml.parse(fs.readFileSync('Cargo.lock', 'utf8'));
+        } catch (error) {
+          if (error.code === 'ENOENT') {
+            core.debug('No Cargo.lock to update');
+          } else {
+            throw error
+          }
+        }
 
-        let cargoUpdated = toml.stringify(json);
-
-        fs.writeFileSync('Cargo.toml', cargoUpdated);
+        if (lockfile != null) {
+          const crate = lockfile.package.find(p => p.name === manifest.package.name);
+          if (crate != null) {
+            crate.version = cargo_version;
+            fs.writeFileSync('Cargo.lock', toml.stringify(lockfile));
+          } else {
+            core.warn(`Self crate (${manifest.package.name}) not present in lockfile packages`);
+          }
+        }
 
         // commit changes
         await exec.exec('git', ['reset', '--soft', 'HEAD~1']);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ const bump = async () => {
               repo: repoForOctokit,
               title: `Automated version bump + changelog for ${version}`,
               head: branchName,
-              base : 'main'
+              base : core.getInput('target_branch')
           });
          
         }


### PR DESCRIPTION
You can see an example PR generated from the modified action here: https://github.com/connec/actions-shenanigans/pull/17/files

---

- 03bbdc6 **fix: Early return if token is unset**

  The check will already be set to fail, so there's no point in going on
  if there is no token.

- 33d4ce4 **feat: Allow target branch to be specified in inputs**

  This will still default to main, preserving the current behaviour.
  However, users could now specify an alternative `target_branch` if
  necessary.

- 6c569df **feat: Also bump Cargo.lock (if present)**

  This prevents uncommitted changes from showing up later.
  
  It would probably be more robust to drive this with `cargo` itself
  (e.g. using `cargo generate-lockfile`) but that would require ensuring
  additional dependencies.
